### PR TITLE
Script para comparar integridad de las actas con resultadosconvzla.com

### DIFF
--- a/README.org
+++ b/README.org
@@ -33,6 +33,11 @@ evita ser bloqueado por el servidor
 sh wget.sh -rc  'https://resultadosconvzla.com/'   
 #+end_src
 
+** md5check.sh
+
+Script que comprueba la integridad de las actas descargadas con las actas alojadas en https://static.resultadosconvzla.com.
+Recibe como parámetro una lista de archivos y por la salida estándar arroja el resultado de md5sum --check
+
 * instrucciones
 ** pasos opcionales :ACLARACIÓN:
 Los pasos 1) y 2) son opcionales, se puede utilizar la lista de URLs ya incluida en el archivo files.txt. 
@@ -97,3 +102,14 @@ chmod 755 count.sh
 #+end_src
 
 Esto generará un archivo en formato CSV llamado actas.csv, conteniendo como campos el número de acta y los votos de cada candidato.
+
+** Comprobar la integridad de las actas descargadas con las actas alojadas en https://static.resultadosconvzla.com.
+
+El script recibe las actas descargadas, calcula el MD5 hash, y luego busca el hash de esa acta en el servidor https://static.resultadosconvzla.com con el mismo nombre de archivo.
+No se descargan las actas del servidor, ya que el servidor ofrece el MD5 hash directamente en el header "etag" de la respuesta HTTP
+
+#+begin_src sh
+cd actas
+md5check.sh *.jpg > md5check.txt
+grep -v OK md5check.txt # mostrará las actas que no lograron pasar la verificación
+#+end_src

--- a/README.org
+++ b/README.org
@@ -38,6 +38,9 @@ sh wget.sh -rc  'https://resultadosconvzla.com/'
 Script que comprueba la integridad de las actas descargadas con las actas alojadas en https://static.resultadosconvzla.com.
 Recibe como parámetro una lista de archivos y por la salida estándar arroja el resultado de md5sum --check
 
+El script recibe las actas descargadas, calcula el MD5 hash, y luego busca el hash de esa acta en el servidor https://static.resultadosconvzla.com con el mismo nombre de archivo.
+No se descargan las actas del servidor, ya que el servidor ofrece el MD5 hash directamente en el header "etag" de la respuesta HTTP
+
 * instrucciones
 ** pasos opcionales :ACLARACIÓN:
 Los pasos 1) y 2) son opcionales, se puede utilizar la lista de URLs ya incluida en el archivo files.txt. 
@@ -105,11 +108,13 @@ Esto generará un archivo en formato CSV llamado actas.csv, conteniendo como cam
 
 ** Comprobar la integridad de las actas descargadas con las actas alojadas en https://static.resultadosconvzla.com.
 
-El script recibe las actas descargadas, calcula el MD5 hash, y luego busca el hash de esa acta en el servidor https://static.resultadosconvzla.com con el mismo nombre de archivo.
-No se descargan las actas del servidor, ya que el servidor ofrece el MD5 hash directamente en el header "etag" de la respuesta HTTP
-
 #+begin_src sh
 cd actas
-md5check.sh *.jpg > md5check.txt
-grep -v OK md5check.txt # mostrará las actas que no lograron pasar la verificación
+sh md5check.sh *.jpg > md5check.txt
+#+end_src
+
+Esto generará un archivo de texto plano conteniendo el resultado que arroja md5sum --check para cada acta. Para filtrar las actas que no lograron pasar la verificación, se puede ejecutar:
+
+#+begin_src sh
+grep -v OK md5check.txt
 #+end_src

--- a/md5check.sh
+++ b/md5check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for filename in $@; do
+  etag=$(curl -I "https://static.resultadosconvzla.com/$filename" | grep etag | sed -E 's/.*?([0-9a-f]{32}).*/\1/')
+  echo "$etag $filename" | md5sum -c
+done


### PR DESCRIPTION
En los headers de https://static.resultadosconvzla.com... hay "etags" y noté q usan el MD5 hash

Asi que hice este script para comparar los hashes de las actas, y noté que de las 24048 actas solo hay 71 que no concuerdan

Nota: el script asume que ambas fuentes tienen el mismo nombre de archivo, y de hecho me tocó renombrar varios archivos q terminaban en `... (1).jpg`.

```bash
rename 's/ ?\(1\)\.jpg/\.jpg/' *
```